### PR TITLE
fix networking deadlock

### DIFF
--- a/lib/sessions/network.js
+++ b/lib/sessions/network.js
@@ -43,15 +43,20 @@ module.exports = class NetworkSession {
     const core = this._corestore.get({ discoveryKey })
     const cbSet = new Set()
     const mainTimeouts = core.timeouts
+    let called = false
+    
     core.timeouts = {
       get: (cb) => {
+        if (called) return cb(null)
         cbSet.add(() => mainTimeouts.get(cb))
       },
       update: (cb) => {
+        if (called) return cb(null)
         cbSet.add(() => mainTimeouts.update(cb))
       }
     }
     return () => {
+      called = true
       core.timeouts = mainTimeouts
       for (const cb of cbSet) cb()
     }

--- a/lib/sessions/network.js
+++ b/lib/sessions/network.js
@@ -44,7 +44,6 @@ module.exports = class NetworkSession {
     const cbSet = new Set()
     const mainTimeouts = core.timeouts
     let called = false
-    
     core.timeouts = {
       get: (cb) => {
         if (called) return cb(null)


### PR DESCRIPTION
happens when one in progress networking call has a mainTimeouts ref to a core.timeouts that gets overwritten in the future