### PR TITLE
Switch upload/download to using a pseudo-buffer instead of a third byteLength param

### DIFF
--- a/test/networked.js
+++ b/test/networked.js
@@ -482,8 +482,8 @@ test('can watch downloads, uploads, and appends', async t => {
   let downloads = 0
   let downloadBytes = 0
   let appends = 0
-  core1.on('upload', (seq, data, byteLength) => { uploads++; uploadBytes += byteLength })
-  core2.on('download', (seq, data, byteLength) => { downloads++; downloadBytes += byteLength })
+  core1.on('upload', (seq, data) => { uploads++; uploadBytes += data.byteLength })
+  core2.on('download', (seq, data) => { downloads++; downloadBytes += data.byteLength })
   core2.on('append', () => (appends++))
 
   await client2.network.configure(core1.discoveryKey, { announce: false, lookup: true })


### PR DESCRIPTION
Turns out that hypercore uses the third param of the `download/upload` events to specify a peer. To maintain compat, we're going to have hyperspace-client emit an object that is "buffer-like" -- it contains no data but has the `length` and `byteLength` params set.

Depends on https://github.com/hypercore-protocol/hyperspace-client/pull/13