### PR TITLE
Add stop method

### DIFF
--- a/server.js
+++ b/server.js
@@ -213,9 +213,8 @@ module.exports = class Hyperspace extends Nanoresource {
     }
   }
 
-  async stop () {
-    await this.close()
-    process.exit(0)
+  stop () {
+    return this.close()
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -212,6 +212,11 @@ module.exports = class Hyperspace extends Nanoresource {
       remoteAddress: remoteAddress ? remoteAddress.host + ':' + remoteAddress.port : ''
     }
   }
+
+  async stop () {
+    await this.close()
+    process.exit(0)
+  }
 }
 
 function callAllInSet (set) {


### PR DESCRIPTION
Adds a `stop` method to the `hyperspace` service.

References:
* https://github.com/hypercore-protocol/hyperspace-rpc/pull/10
* https://github.com/hypercore-protocol/hyperspace-client/pull/14