### PR TITLE
Add stable swarm ID and noise keypair to network options

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "hypercore": "^9.5.4",
     "hypercore-cache": "^1.0.2",
     "hypercore-default-storage": "^1.0.0",
+    "hypercore-protocol": "^8.0.7",
     "hyperswarm": "^2.15.1",
     "hypertrie": "^5.1.1",
     "inspect-custom-symbol": "^1.1.1",

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -42,7 +42,7 @@ async function createMany (numDaemons, opts) {
     return bootstrapper.once('listening', resolve)
   })
   const bootstrapPort = bootstrapper.address().port
-  const bootstrapOpt = [`localhost:${bootstrapPort}}`]
+  const bootstrapOpt = [`localhost:${bootstrapPort}`]
 
   for (let i = 0; i < numDaemons; i++) {
     const serverOpts = opts ? Array.isArray(opts) ? opts[i] : opts : null


### PR DESCRIPTION
The swarm ID + Noise keypair are currently being rotated across restarts. With this fix, Hyperspace will derive them from the Corestore, like we did in the old Hyperdrive daemon.

The `_deriveSeed` Corestore is still considered private, so this fix will need to be updated when we re-evaluate that part of the API. 