### PR TITLE
Fix: remove tracked download resources to avoid erroneous double-releases

### DIFF
--- a/lib/sessions/hypercore.js
+++ b/lib/sessions/hypercore.js
@@ -103,10 +103,14 @@ module.exports = class HypercoreSession {
     const opts = { start, end: live ? -1 : end, blocks: blocks.length ? blocks : null, linear }
     return new Promise((resolve, reject) => {
       let downloaded = false
+      let downloadSet
       const d = core.download(opts, (err) => {
         downloaded = true
         if (this._sessionState.hasResource(resourceId)) {
           this._sessionState.deleteResource(resourceId)
+        }
+        if (downloadSet) {
+          downloadSet.delete(resourceId)
         }
         if (err) return reject(err)
         return resolve()
@@ -115,7 +119,7 @@ module.exports = class HypercoreSession {
       this._sessionState.addResource(resourceId, d, () => {
         core.undownload(d)
       })
-      let downloadSet = this._downloads.get(id)
+      downloadSet = this._downloads.get(id)
       if (!downloadSet) {
         downloadSet = new Set()
         this._downloads.set(id, downloadSet)


### PR DESCRIPTION
In my ctzn tests, I had remote hyperbees throw the following error during a hypercore `.close()`:

```
/Users/paulfrazee/work/ctzn/node_modules/@hyperspace/rpc/index.js:11
    const err = new Error(message)
                ^

Error: Invalid resource: 12628
    at Object.decode (/Users/paulfrazee/work/ctzn/node_modules/@hyperspace/rpc/index.js:11:17)
    at RPC._onmessage (/Users/paulfrazee/work/ctzn/node_modules/arpeecee/index.js:113:33)
    at Parser._nextState (/Users/paulfrazee/work/ctzn/node_modules/arpeecee/parser.js:127:14)
    at Parser._readMessage (/Users/paulfrazee/work/ctzn/node_modules/arpeecee/parser.js:54:19)
    at Parser.recv (/Users/paulfrazee/work/ctzn/node_modules/arpeecee/parser.js:35:44)
    at RPC._write (/Users/paulfrazee/work/ctzn/node_modules/arpeecee/index.js:170:22)
    at WritableState.update (/Users/paulfrazee/work/ctzn/node_modules/streamx/index.js:168:14)
    at updateWriteNT (/Users/paulfrazee/work/ctzn/node_modules/streamx/index.js:479:6)
    at processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: '',
  errno: 0,
  details: ''
}
```

I tracked this down to the `deleteResource()` calls which were releasing active downloads. Turns out completed downloads were not being removed from the set of tracked download-resources, leading to this error due to a double-release.

The PR fixes this by removing a completed download from the set.